### PR TITLE
allow custom delimiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
 
-function parse(str) {
+function parse(str, delimiter) {
   const lines      = str.split('\n').filter(line => line);
-  const headers    = parseLine(lines.shift());
-  const rows       = lines.map(parseLine);
+  const headers    = parseLine(lines.shift(), delimiter);
+  const rows       = lines.map((line) => parseLine(line, delimiter));
   const objectRows = rows.map(function(row) {
     return row.reduce(function(object, column, index) {
       const name   = headers[index];
@@ -20,25 +20,30 @@ function parse(str) {
 // This is a modified version of the world-famous CSVToArray by Ben Nadel:
 // http://www.bennadel.com/blog/1504-ask-ben-parsing-csv-strings-with-javascript-exec-regular-expression-command.htm
 
-const DELIMITER = ',';
-const FIELDS    = new RegExp(
-  // Delimiters.
-  `(\\${DELIMITER}|^)` +
-  // Quoted fields.
-  `(?:"([^"]*(?:""[^"]*)*)"|` +
-  // Standard fields.
-  `([^"\\${DELIMITER}]*))`
-,
-'gi');
+function tokenize (delimiter) {
+  if (!delimiter)
+    delimiter = ',';
+
+    return new RegExp(
+    // Delimiters.
+    `(\\${delimiter}|^)` +
+    // Quoted fields.
+    `(?:"([^"]*(?:""[^"]*)*)"|` +
+    // Standard fields.
+    `([^"\\${delimiter}]*))`
+  ,
+  'gi');
+}
 
 
-function parseLine(str) {
+function parseLine(str, delimiter) {
   if (!str)
     return null;
 
+  const regexp = tokenize(delimiter);
   const row = [];
   let   match;
-  while (match = FIELDS.exec(str)){
+  while (match = regexp.exec(str)){
     if (match[2]) {
       // We found a quoted value. When we capture
       // this value, unescape any double quotes.

--- a/test.js
+++ b/test.js
@@ -23,3 +23,15 @@ test('ignore empty lines', function(t) {
   t.equal(result[1].fullname, 'Henning Mankel');
   t.end();
 });
+
+test('allow custom delimiter', function (t) {
+  const result = mincsv.parse(`
+name:age
+george:23
+matthew:31
+giulia:26
+  `, ':');
+  t.equal(result[0].name, 'george');
+  t.equal(result[0].age, '23');
+  t.end();
+})


### PR DESCRIPTION
Thanks for this module!

This PR updates the following:
- Allows custom delimiters instead of just `,`. The default is still `,` so no breaking changes here.
- Ignores `node_modules` to prevent accidental stashing

I matched your JS style the best I could but an eslinter would be helpful.
